### PR TITLE
Add nix build method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,45 @@ Note: Windows Terminal performance is slow for some effects.
 OR
 ```pipx install terminaltexteffects```
 
+### Nix (flakes)
+
+Add it as an input to a flake:
+```nix
+inputs = {
+  terminaltexteffects.url = "github:ChrisBuilds/terminaltexteffects/<optional-ref>"
+}
+````
+
+Create a shell with it:
+```nix
+nix shell github:ChrisBuilds/terminaltexteffects/<optional-ref>
+```
+
+Or run it directly:
+
+```nix
+echo 'terminaltexteffects is awesome' | nix run github:ChrisBuilds/terminaltexteffects/<optional-ref> -- beams
+```
+
+### Nix (classic)
+
+Fetch the source and add it to, e.g. your shell:
+```nix
+let
+  pkgs = import <nixpkgs> {};
+
+  tte = pkgs.callPackage (pkgs.fetchFromGitHub {
+    owner = "ChrisBuilds";
+    repo = "terminaltexteffects";
+    rev = "<revision, e.g. main/v0.10.0/etc.>";
+    hash = ""; # Build first, put proper hash in place
+  }) {};
+in
+  pkgs.mkShell {
+    packages = [tte];
+  }
+```
+
 ## Usage
 
 View the [Documentation](https://chrisbuilds.github.io/terminaltexteffects/) for a full installation and usage guide.

--- a/default.nix
+++ b/default.nix
@@ -1,19 +1,20 @@
 {
   self,
-  version,
   python312Packages,
-}:
-python312Packages.buildPythonApplication {
-  pname = "terminaltexteffects";
-  inherit version;
+}: let
+  version = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry.version;
+in
+  python312Packages.buildPythonApplication {
+    pname = "terminaltexteffects";
+    inherit version;
 
-  src = self;
+    src = self;
 
-  pyproject = true;
+    pyproject = true;
 
-  nativeBuildInputs = [
-    python312Packages.poetry-core
-  ];
+    nativeBuildInputs = [
+      python312Packages.poetry-core
+    ];
 
-  meta.mainProgram = "tte";
-}
+    meta.mainProgram = "tte";
+  }

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,16 @@
-{
-  self,
-  python312Packages,
-}: let
-  version = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry.version;
+{python312Packages}: let
+  poetryDef = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry;
+
+  name = poetryDef.name;
 in
   python312Packages.buildPythonApplication {
     pname = "terminaltexteffects";
-    inherit version;
+    inherit (poetryDef) version;
 
-    src = self;
+    src = builtins.path {
+      path = ./.;
+      name = name;
+    };
 
     pyproject = true;
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,13 @@
-{python312Packages}: let
+{
+  lib,
+  python312Packages,
+}: let
   poetryDef = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry;
 
   name = poetryDef.name;
 in
   python312Packages.buildPythonApplication {
-    pname = "terminaltexteffects";
+    pname = name;
     inherit (poetryDef) version;
 
     src = builtins.path {
@@ -18,5 +21,11 @@ in
       python312Packages.poetry-core
     ];
 
-    meta.mainProgram = "tte";
+    meta = {
+      inherit (poetryDef) description;
+      maintainers = poetryDef.authors;
+      homepage = "https://github.com/ChrisBuilds/${name}";
+      license = lib.licenses.mit;
+      mainProgram = "tte";
+    };
   }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{
+  self,
+  version,
+  python312Packages,
+}:
+python312Packages.buildPythonApplication {
+  pname = "terminaltexteffects";
+  inherit version;
+
+  src = self;
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    python312Packages.poetry-core
+  ];
+
+  meta.mainProgram = "tte";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -7,16 +7,16 @@
   };
 
   outputs = {
-    self,
     systems,
     nixpkgs,
+    ...
   }: let
     forEachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
   in {
     formatter = forEachSystem (pkgs: pkgs.alejandra);
 
     packages = forEachSystem (pkgs: {
-      default = pkgs.callPackage ./default.nix {inherit self;};
+      default = pkgs.callPackage ./default.nix {};
     });
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Visual effects applied to text in the terminal. ";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = {
+    self,
+    systems,
+    nixpkgs,
+  }: let
+    forEachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
+
+    version = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry.version;
+  in {
+    formatter = forEachSystem (pkgs: pkgs.alejandra);
+
+    packages = forEachSystem (pkgs: {
+      default = pkgs.callPackage ./default.nix {inherit version self;};
+    });
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,13 +12,11 @@
     nixpkgs,
   }: let
     forEachSystem = f: nixpkgs.lib.genAttrs (import systems) (system: f nixpkgs.legacyPackages.${system});
-
-    version = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry.version;
   in {
     formatter = forEachSystem (pkgs: pkgs.alejandra);
 
     packages = forEachSystem (pkgs: {
-      default = pkgs.callPackage ./default.nix {inherit version self;};
+      default = pkgs.callPackage ./default.nix {inherit self;};
     });
   };
 }


### PR DESCRIPTION
This PR adds a flake and default.nix, allowing Nix users to use this project

For people who want to use this *right now*, you can refer to this code as follows:
```nix
github:ChrisBuilds/terminaltexteffects/pull/25/head#default
```
Or use my fork directly before merge:
```nix
github:Dich0tomy/terminaltexteffects/feat/add-nix-build-method
```
But note that this ref is volatile and the branch will get deleted after this PR gets merged.