### PR TITLE
fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,7 +253,7 @@ the symbol that will be printed after the effect completes. Set to `''` or `' '`
 * Terminal: If a terminal object is instantiated without a TerminalConfig passed, it will instantiate a new TerminalConfig.
 * Terminal: Terminal.get_formatted_output_string() will return a string representing the current frame.
 * Terminal: Terminal.print() will print the frame to the terminal and handle cursor position. The optional argument (enforce_frame_rate: bool = True) determines if the frame rate set at Terminal.config.frame_rate is enforced. If set to False, the print will occur without delay.
-* New argument validator for terminal dimensions (argvalidators.TerminalDeminsions).
+* New argument validator for terminal dimensions (argvalidators.TerminalDimensions).
 * New module base_effect.py:
 * base_effect.BaseEffect:
   * This is an abstract class which forms the base iterable for all effects and provides the terminal_output() context manager.
@@ -290,13 +290,13 @@ the symbol that will be printed after the effect completes. Set to `''` or `' '`
 * graphics.Gradient.build_coordinate_color_mapping() will map gradient colors to coordinates in the terminal and supports a Gradient.Direction argument to enable gradients in the following directions: horizontal, vertical, diagonal, center
 * graphics.Gradient, if printed, will show a colored spectrum and the description of its stops and steps.
 * The Scene class has a new method: apply_gradient_to_symbols(). This method will iterate over a list of symbols and apply the colors from a gradient to the symbols. A frame with the symbol will be added for each color starting from the last color used in the previous symbol, up to the the index determined by the ratio of the current symbol's index in the symbols list to the total length of the list. This method allows scenes to automatically create frames from a list of symbols and gradient of arbitrary length while ensuring every symbol and color is displayed.
-* On instatiation, Terminal creates EffectCharacters for every coordinate in the canvas that does not have an input character. These EffectCharacters have the symbol " " and are stored in Terminal._fill_characters as well as added to Terminal.character_by_input_coord.
+* On instantiation, Terminal creates EffectCharacters for every coordinate in the canvas that does not have an input character. These EffectCharacters have the symbol " " and are stored in Terminal._fill_characters as well as added to Terminal.character_by_input_coord.
 * argvalidators.IntRange will validate a range specified as "int-int" and return a tuple[int,int].
 * argvalidators.FloatRange will validate a range of floats specified as "float-float" and return a tuple[float, float].
 * character.animation.set_appearance(symbol, color) will set the character symbol and color directly. If a Scene is active, the appearance will be overwritten with the Scene frame on the next call to step_animation(). This method is intended for the occasion where a full scene isn't needed, or the appearance needs to be set based on conditions not compatible with Scenes or the EventHandler. For example, setting the color based on the terminal row.
 * Terminal.CharacterSort enums moved to Terminal.CharacterGroup, Terminal.CharacterSort is now used for sorting and return a flat list of characters.
 * Terminal.CharacterSort has new sort methods, TOP_TO_BOTTOM_LEFT_TO_RIGHT, TOP_TO_BOTTOM_RIGHT_TO_LEFT, BOTTOM_TO_TOP_LEFT_TO_RIGHT, BOTTOM_TO_TOP_RIGHT_TO_LEFT, OUTSIDE_ROW_TO_MIDDLE, MIDDLE_ROW_TO_OUTSIDE
-* New Terminal.CharacterGroup options, CENTER_TO_OUTSIDE_DIAMONDS and OUTSIDE_TO_CENTER_DIAMONS
+* New Terminal.CharacterGroup options, CENTER_TO_OUTSIDE_DIAMONDS and OUTSIDE_TO_CENTER_DIAMONDS
 * graphics.Animation.adjust_color_brightness(color: graphics.Color, brightness: float) will convert the color to HSL, adjust the brightness to the given level, and return
   an RGB hex string.
 * CTRL-C keyboard interrupt during a running effect will exit gracefully.
@@ -337,11 +337,11 @@ the symbol that will be printed after the effect completes. Set to `''` or `' '`
 * Geometry related methods have been removed from the motion class. They are now located at terminaltexteffects.utils.geometry as separate functions.
 * The Coord() object definition has been moved from the motion module to the geometry module.
 * Terminal.add_character() takes a geometry.Coord() argument to set the character's input_coordinate.
-* EffectCharacters have a unique ID set by the Terminal on instatiation. As a result, all EffectCharacters should be created using Terminal.add_character().
+* EffectCharacters have a unique ID set by the Terminal on instantiation. As a result, all EffectCharacters should be created using Terminal.add_character().
 * EffectCharacters added by the effect are stored in Terminal._added_characters.
 * Retrieving EffectCharacters from the terminal should no longer be done via accessing the lists of characters [_added_characters, _fill_characters, _input_characters], but should be retrieved via Terminal.get_characters() and Terminal.get_characters_sorted().
 * Setting EffectCharacter visibility is now done via Terminal.set_character_visibility(). This enables the terminal to keep track of all visible characters without needing to iterate over all characters on every call to _update_terminal_state().
-* EventHandler.Action.SET_CHARACTER_VISIBILITY_STATE has been removed as visibilty state is handled by the Terminal. To enable visibility state changes through the event system, use a CALLBACK action with target EventHandler.Callback(terminal.set_character_visibility, True/False).
+* EventHandler.Action.SET_CHARACTER_VISIBILITY_STATE has been removed as visibility state is handled by the Terminal. To enable visibility state changes through the event system, use a CALLBACK action with target EventHandler.Callback(terminal.set_character_visibility, True/False).
 * geometry.find_coords_on_circle() num_points arg renamed to points_limit and new arg unique: bool, added to remove any duplicate Coords.
 * The animation rate argument (-a, --animation-rate) has been removed from all effects and is handled as a terminal argument specified prior to the effect name.
 * argtypes.py has been renamed argvalidators.py and all functions have been refactored into classes with a METAVAR class member and a type_parser method.

--- a/docs/changeblog/changeblog.md
+++ b/docs/changeblog/changeblog.md
@@ -1,9 +1,9 @@
 # ChangeBlog Home
 
 The ChangeBlog features explanatory documentation for each release. Blog entries will explain the major features of a
-given release and provide in-depth explainations of TTE Engine features.
+given release and provide in-depth explanations of TTE Engine features.
 
 ## Release Entries
 
 * [0.11.0 - Matrix Effect and Canvas+Text Anchoring](./changeblog_0.11.0.md)
-* [0.10.0 - ColorShift, Canvas, Better Compatibililty, and more Customization](./changeblog_0.10.0.md)
+* [0.10.0 - ColorShift, Canvas, Better Compatibility, and more Customization](./changeblog_0.10.0.md)

--- a/docs/changeblog/changeblog_0.10.0.md
+++ b/docs/changeblog/changeblog_0.10.0.md
@@ -2,7 +2,7 @@
 
 ## Release 0.10.0
 
-### ColorShift, Canvas, Better Compatibililty, and more Customization
+### ColorShift, Canvas, Better Compatibility, and more Customization
 
 This release comes with a shiny new effect [ColorShift](../showroom.md#colorshift), increased customization for
 [Waves](../showroom.md#waves) and [Wipe](../showroom.md#wipe) as well as renaming the

--- a/docs/changeblog/changeblog_0.11.0.md
+++ b/docs/changeblog/changeblog_0.11.0.md
@@ -74,7 +74,7 @@ Here is the result of my analysis.
 
     `Symbols and Colors in a given cell change randomly and separately`
 
-    : The changes to symbol and color for a given character cell are not linked and must be calculcated separately.
+    : The changes to symbol and color for a given character cell are not linked and must be calculated separately.
 
     `The number of visible characters in a column varies from just a few, to the entire column`
 
@@ -325,7 +325,7 @@ resulting effect looks better.
 ![spray_wide_canvas](../img/changeblog_media/0.11.0/spray_wide_canvas_anchored.gif)
 
 All these changes with the Canvas has led to some additional complexity when ensuring all effects operate in reference
-to the Canvas dimensions properly in addition to the complexity handling the interactions between achoring, text wrapping,
+to the Canvas dimensions properly in addition to the complexity handling the interactions between anchoring, text wrapping,
 and ignoring the terminal dimensions when appropriate. I'm sure there are edge cases somebody will find and report.
 Looking forward to fixing those.
 

--- a/docs/libguide.md
+++ b/docs/libguide.md
@@ -70,7 +70,7 @@ All effect configuration options are available within each effect via the `effec
     in from alternating sides of the terminal.
     2. Columns will slide in, rather than rows.
     3. Change the gradient colors from the defaults.
-    4. Set the canvas width manually rather than automatically detect. Canvas heigth will be automatically detected as it has not been set.
+    4. Set the canvas width manually rather than automatically detect. Canvas height will be automatically detected as it has not been set.
 
 === "Output"
     ![t](./img/lib_demos/libguide_configuration_output.gif)

--- a/docs/showroom.md
+++ b/docs/showroom.md
@@ -555,7 +555,7 @@ Text expands in a single row or column in the middle of the canvas then out.
     --expand-direction {vertical,horizontal}
                         Direction the text will expand. (default: vertical)
     --center-movement-speed (float > 0)
-                        Speed of the characters during the initial expansion of the center vertical/horiztonal line. Note: Speed effects the number of steps in the easing function. Adjust speed and animation
+                        Speed of the characters during the initial expansion of the center vertical/horizontal line. Note: Speed effects the number of steps in the easing function. Adjust speed and animation
                         rate separately to fine tune the effect. (default: 0.35)
     --full-movement-speed (float > 0)
                         Speed of the characters during the final full expansion. Note: Speed effects the number of steps in the easing function. Adjust speed and animation rate separately to fine tune the

--- a/terminaltexteffects/effects/effect_beams.py
+++ b/terminaltexteffects/effects/effect_beams.py
@@ -274,8 +274,8 @@ class BeamsIterator(BaseEffectIterator[BeamsConfig]):
                 beam_row_scn.apply_gradient_to_symbols(fade_gradient, character.input_symbol, 5)
                 beam_column_scn.apply_gradient_to_symbols(fade_gradient, character.input_symbol, 5)
                 brighten_gradient = Gradient(faded_color, self.character_final_color_map[character], steps=10)
-                brigthen_scn = character.animation.new_scene(id="brighten")
-                brigthen_scn.apply_gradient_to_symbols(
+                brighten_scn = character.animation.new_scene(id="brighten")
+                brighten_scn.apply_gradient_to_symbols(
                     brighten_gradient, character.input_symbol, self.config.final_gradient_frames
                 )
         self.pending_groups = groups

--- a/terminaltexteffects/effects/effect_middleout.py
+++ b/terminaltexteffects/effects/effect_middleout.py
@@ -42,7 +42,7 @@ class MiddleOutConfig(ArgsDataClass):
         final_gradient_steps (tuple[int, ...] | int): Tuple of the number of gradient steps to use. More steps will create a smoother and longer gradient animation. Valid values are n > 0.
         final_gradient_direction (Gradient.Direction): Direction of the final gradient.
         expand_direction (typing.Literal["vertical", "horizontal"]): Direction the text will expand. Choices: vertical, horizontal.
-        center_movement_speed (float): Speed of the characters during the initial expansion of the center vertical/horiztonal. Valid values are n > 0.
+        center_movement_speed (float): Speed of the characters during the initial expansion of the center vertical/horizontal. Valid values are n > 0.
         full_movement_speed (float): Speed of the characters during the final full expansion. Valid values are n > 0.
         center_easing (easing.EasingFunction): Easing function to use for initial expansion.
         full_easing (easing.EasingFunction): Easing function to use for full expansion."""
@@ -98,9 +98,9 @@ class MiddleOutConfig(ArgsDataClass):
         type_parser=argvalidators.PositiveFloat.type_parser,
         default=0.35,
         metavar=argvalidators.PositiveFloat.METAVAR,
-        help="Speed of the characters during the initial expansion of the center vertical/horiztonal line. ",
+        help="Speed of the characters during the initial expansion of the center vertical/horizontal line. ",
     )  # type: ignore[assignment]
-    """float : Speed of the characters during the initial expansion of the center vertical/horiztonal line. """
+    """float : Speed of the characters during the initial expansion of the center vertical/horizontal line. """
 
     full_movement_speed: float = ArgField(
         cmd_name="--full-movement-speed",

--- a/terminaltexteffects/engine/base_effect.py
+++ b/terminaltexteffects/engine/base_effect.py
@@ -5,7 +5,7 @@ effect iterator interface as well as the effect configuration and terminal confi
 
 Classes:
     BaseEffectIterator(Generic[T]): An abstract base class that defines the basic structure for an iterator
-        that applies a certain effect to the input data. Provides initilization for the effect configuration and terminal
+        that applies a certain effect to the input data. Provides initialization for the effect configuration and terminal
         as well as the `__iter__` method.
 
     BaseEffect(Generic[T]): An abstract base class that defines the basic structure for an effect. Provides the `__iter__`

--- a/terminaltexteffects/utils/graphics.py
+++ b/terminaltexteffects/utils/graphics.py
@@ -127,7 +127,7 @@ class Gradient:
         Initializes a Graphics object.
 
         Args:
-            stops (Color): One ore more variables of type Color representing the color stops.
+            stops (Color): One or more variables of type Color representing the color stops.
             steps (int | tuple[int, ...], optional): Number of steps or a tuple of step values for generating the
                 spectrum. Defaults to 1.
             loop (bool, optional): Loop the gradient. This causes the final gradient color to transition back to the first gradient color. Defaults to False.


### PR DESCRIPTION
found via `codespell -H` and `typos --hidden --format brief`