### PR TITLE
Test for TerminalConfig option --no-eol

### DIFF
--- a/tests/engine_tests/test_terminal.py
+++ b/tests/engine_tests/test_terminal.py
@@ -577,6 +577,14 @@ def test_terminal_restore_cursor_end_symbol(capsys):
     assert captured.out == "\x1b[?25htest"
 
 
+def test_terminal_restore_cursor_end_symbol_no_eol(capsys):
+    config = TerminalConfig(no_eol=True)
+    terminal = Terminal(input_data="abcd\nefgh\nijkl", config=config)
+    terminal.restore_cursor()
+    captured = capsys.readouterr()
+    assert captured.out == "\x1b[?25h"
+
+
 def test_terminal_print(capsys):
     config = TerminalConfig()
     terminal = Terminal(input_data="abcd\nefgh\nijkl", config=config)


### PR DESCRIPTION
Adding a test for the proposed TerminalConfig option `--no-eol`.

Test passes with the `--no-eol` patch in place. But I am not sure that setting the parameter `no_eol` here is correct.