### PR TITLE
fix: --no-eol option doesnt show cursor

### DIFF
--- a/terminaltexteffects/engine/terminal.py
+++ b/terminaltexteffects/engine/terminal.py
@@ -1116,7 +1116,8 @@ class Terminal:
         """
         if self.config.no_eol:
             end_symbol = ""
-        sys.stdout.write(ansitools.show_cursor())
+        else:
+            sys.stdout.write(ansitools.show_cursor())
         sys.stdout.write(end_symbol)
 
     def print(self, output_string: str) -> None:


### PR DESCRIPTION
at the end of effects; beams, sweep and overflow with option --no-eol, there was a visible cursor at the end of the terminal, this is not desired behaviour for --no-eol option.

so with this changes, when --no-eol option is set, the cursor wont be visible at the end.

related:
https://github.com/basecamp/omarchy/issues/3418