### PR TITLE
Update default.nix to use hatchling over poetry

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,13 +2,13 @@
   lib,
   python312Packages,
 }: let
-  poetryDef = with builtins; (fromTOML (readFile ./pyproject.toml)).tool.poetry;
+  hatchlingDef = with builtins; (fromTOML (readFile ./pyproject.toml)).project;
 
-  name = poetryDef.name;
+  name = hatchlingDef.name;
 in
   python312Packages.buildPythonApplication {
     pname = name;
-    inherit (poetryDef) version;
+    inherit (hatchlingDef) version;
 
     src = builtins.path {
       path = ./.;
@@ -18,12 +18,12 @@ in
     pyproject = true;
 
     nativeBuildInputs = [
-      python312Packages.poetry-core
+      python312Packages.hatchling
     ];
 
     meta = {
-      inherit (poetryDef) description;
-      maintainers = poetryDef.authors;
+      inherit (hatchlingDef) description;
+      maintainers = hatchlingDef.authors;
       homepage = "https://github.com/ChrisBuilds/${name}";
       license = lib.licenses.mit;
       mainProgram = "tte";


### PR DESCRIPTION
Running this program from the Github repository with `nix` (classic and flakes) has been broken since this commit: 9d7c87d782d8061c9afe3e3ba5da101cff4e9f0c.

This PR aims to update the relevant Nix file so we can use `nix` to run `tte` again.

To test this PR with `nix run`: 
```sh
echo 'this is awesome' | nix run github:ChrisBuilds/terminaltexteffects/pull/63/head -- --random-effect
```