### PR TITLE
Add optional seed parameter for reproducible random effects

### DIFF
--- a/terminaltexteffects/__main__.py
+++ b/terminaltexteffects/__main__.py
@@ -42,6 +42,12 @@ def build_parsers_and_parse_args() -> tuple[argparse.Namespace, dict[str, tuple[
         version="TerminalTextEffects " + version("terminaltexteffects"),
     )
     parser.add_argument("--random-effect", "-R", action="store_true", help="Randomly select an effect to apply")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed to use for random effect selection",
+    )
     random_include_exclude_group = parser.add_mutually_exclusive_group()
     random_include_exclude_group.add_argument(
         "--include-effects",
@@ -106,6 +112,8 @@ def main() -> None:
         sys.exit(1)
 
     if args.random_effect:
+        if args.seed is not None:
+            random.seed(args.seed)
         if args.include_effects:
             available_effects = [effect for effect in effect_resource_map if effect in args.include_effects]
         elif args.exclude_effects:

--- a/terminaltexteffects/__main__.py
+++ b/terminaltexteffects/__main__.py
@@ -96,6 +96,8 @@ def build_parsers_and_parse_args() -> tuple[argparse.Namespace, dict[str, tuple[
 def main() -> None:
     """Run the terminaltexteffects command line interface."""
     args, effect_resource_map = build_parsers_and_parse_args()
+    if args.seed is not None:
+        random.seed(args.seed)
     if args.input_file:
         try:
             input_data = Path(args.input_file).read_text(encoding="UTF-8")
@@ -112,8 +114,6 @@ def main() -> None:
         sys.exit(1)
 
     if args.random_effect:
-        if args.seed is not None:
-            random.seed(args.seed)
         if args.include_effects:
             available_effects = [effect for effect in effect_resource_map if effect in args.include_effects]
         elif args.exclude_effects:


### PR DESCRIPTION
This PR adds an optional --seed parameter to the CLI to allow deterministic
random effects across multiple runs.

- Introduces a --seed flag
- Initializes the RNG with the provided seed when present
- Preserves existing behavior when no seed is specified

This enables reproducible animations for demos, recordings, testing, and
synchronized random effects across multiple instances.

Happy to adjust naming or behavior if desired.
