### PR TITLE
Fix scene lifecycle issues and make custom effect loading more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@
 ---
 
 * Animation - Fixed `adjust_color_brightness()` rounding so a brightness factor of `1` preserves mixed-channel RGB colors instead of subtly darkening individual channels.
+* Animation - Looping sequential and eased scenes now trigger `SCENE_COMPLETE` once at each completed loop boundary;
+  synced looping scenes no longer trigger the event on every animation tick or discard their frames when no motion
+  path is active.
+* Animation - `Scene.apply_gradient_to_symbols()` now rejects empty symbol sequences and symbols that are not exactly
+  one character long with an `AnimationSceneError`.
+* Animation - Creating a scene with an explicit ID that is already in use now raises `DuplicateSceneIDError` instead
+  of silently replacing the original scene.
+* Application - Invalid user effect plugins now produce a path-specific warning and are skipped without hiding
+  built-in effects or other valid user plugins.
 * Blackhole - Fixed repeated in-process renders mutating cached circle coordinates during the collapse phase, which
   could cause later runs with the same canvas geometry to fail with an `IndexError`.
 * Thunderstorm - Fixed `text_glow_time` being ignored due to a hardcoded frame duration. It now controls the number

--- a/docs/appguide.md
+++ b/docs/appguide.md
@@ -59,6 +59,8 @@ ls | tte --random-effect --seed 123 --include-effects beams decrypt rain
 Custom effect modules are discovered from `${XDG_CONFIG_HOME}/terminaltexteffects/effects`, or
 `~/.config/terminaltexteffects/effects` when `XDG_CONFIG_HOME` is not set. Any `.py` file in that directory that
 provides `get_effect_resources()` can register an effect command alongside the built-in effects.
+If a custom effect cannot be imported or registered, TTE prints a warning to standard error, skips that file, and
+keeps the built-in effects and other valid custom effects available.
 
 The example below will pass the output of the `ls` command to TTE with the following options:
 

--- a/terminaltexteffects/__main__.py
+++ b/terminaltexteffects/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import importlib.util
 import os
@@ -25,20 +26,136 @@ if TYPE_CHECKING:
     from terminaltexteffects.engine.base_effect import BaseEffect
 
 
+def _get_effect_resources(
+    module: ModuleType,
+) -> tuple[str, type[BaseEffect], type[BaseConfig]] | None:
+    """Return validated effect resources from a module when provided."""
+    if not hasattr(module, "get_effect_resources"):
+        return None
+    resources = module.get_effect_resources()
+    if not isinstance(resources, tuple) or len(resources) != 3:
+        msg = "get_effect_resources() must return a three-item tuple"
+        raise ValueError(msg)
+    return resources
+
+
+def _register_effect_resources(
+    resources: tuple[str, type[BaseEffect], type[BaseConfig]],
+    subparsers: argparse._SubParsersAction,
+    effect_resource_map: dict[str, tuple[type[BaseEffect], type[BaseConfig]]],
+) -> None:
+    """Register effect resources and populate their CLI options.
+
+    The configuration parser is populated before the resource map is mutated so a
+    parser failure cannot leave an effect command that is not invokable.
+
+    Raises:
+        ValueError: If the effect command has already been registered.
+
+    """
+    effect_cmd, effect_class, config_class = resources
+    if effect_cmd in effect_resource_map:
+        msg = f"Duplicate effect command detected: {effect_cmd}"
+        raise ValueError(msg)
+    previous_choices = dict(subparsers.choices)
+    previous_choice_actions = list(subparsers._choices_actions)
+    parser_populated = False
+    try:
+        config_class._populate_parser(subparsers)
+        parser_populated = True
+    finally:
+        if not parser_populated:
+            subparsers.choices.clear()
+            subparsers.choices.update(previous_choices)
+            subparsers._choices_actions[:] = previous_choice_actions
+    effect_resource_map[effect_cmd] = (effect_class, config_class)
+
+
+def _validate_user_effect_resources(
+    resources: tuple[str, type[BaseEffect], type[BaseConfig]],
+    effect_resource_map: dict[str, tuple[type[BaseEffect], type[BaseConfig]]],
+) -> None:
+    """Validate user resources against disposable parser state."""
+    effect_cmd, _, config_class = resources
+    if not isinstance(effect_cmd, str) or not effect_cmd:
+        msg = "Effect command must be a non-empty string"
+        raise ValueError(msg)
+    if effect_cmd in effect_resource_map:
+        msg = f"Duplicate effect command detected: {effect_cmd}"
+        raise ValueError(msg)
+    parser_spec = config_class.parser_spec
+    if parser_spec.name != effect_cmd:
+        msg = f"Effect command '{effect_cmd}' does not match parser command '{parser_spec.name}'"
+        raise ValueError(msg)
+
+
+def _warn_user_plugin(plugin_file: Path, exc: Exception) -> None:
+    """Write a non-fatal user plugin warning to stderr."""
+    print(
+        f"Warning: Failed to load user effect plugin '{plugin_file}': {type(exc).__name__}: {exc}",
+        file=sys.stderr,
+    )
+
+
+def _load_user_effect_module(plugin_file: Path, module_name: str) -> ModuleType:
+    """Load one user effect module under its collision-safe module name."""
+    spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+    if spec is None or spec.loader is None:
+        msg = "Unable to create a module specification"
+        raise ImportError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _register_discovered_effects(
+    subparsers: argparse._SubParsersAction,
+    effect_resource_map: dict[str, tuple[type[BaseEffect], type[BaseConfig]]],
+) -> None:
+    """Register built-in effects and isolate failures in user effect plugins."""
+    for module_info in pkgutil.iter_modules(
+        terminaltexteffects.effects.__path__,
+        terminaltexteffects.effects.__name__ + ".",
+    ):
+        module = importlib.import_module(module_info.name)
+        resources = _get_effect_resources(module)
+        if resources is not None:
+            _register_effect_resources(resources, subparsers, effect_resource_map)
+
+    plugins_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "terminaltexteffects" / "effects"
+    if not plugins_dir.exists():
+        return
+
+    for plugin_file in sorted(plugins_dir.glob("*.py")):
+        if plugin_file.name == "__init__.py":
+            continue
+        path_digest = hashlib.sha256(str(plugin_file.resolve()).encode()).hexdigest()[:12]
+        module_name = f"_terminaltexteffects_user_effect_{plugin_file.stem}_{path_digest}"
+        try:
+            module = _load_user_effect_module(plugin_file, module_name)
+            resources = _get_effect_resources(module)
+            if resources is not None:
+                _validate_user_effect_resources(resources, effect_resource_map)
+                _register_effect_resources(resources, subparsers, effect_resource_map)
+        except Exception as exc:  # noqa: BLE001
+            sys.modules.pop(module_name, None)
+            _warn_user_plugin(plugin_file, exc)
+
+
 def build_parser() -> tuple[argparse.ArgumentParser, dict[str, tuple[type[BaseEffect], type[BaseConfig]]]]:
     """Build the CLI parser and discover available effects.
 
-    This includes registering built-in effect modules and user-provided effect
-    modules from the XDG config effects directory, then returning the parsed CLI
-    parser together with a mapping of effect command names to their effect and
-    config classes.
+    This includes registering built-in effect modules and valid user-provided effect
+    modules from the XDG config effects directory. User modules that fail to import
+    or register are skipped with a warning to standard error.
 
     Returns:
         tuple[argparse.ArgumentParser, dict[str, tuple[type[BaseEffect], type[BaseConfig]]]]: The CLI parser and a
             mapping of effect names to their classes and configurations.
 
     Raises:
-        ValueError: If two discovered effect modules register the same effect command.
+        ValueError: If built-in effect modules register the same effect command.
 
     """
     parser = argparse.ArgumentParser(
@@ -95,51 +212,7 @@ def build_parser() -> tuple[argparse.ArgumentParser, dict[str, tuple[type[BaseEf
 
     effect_resource_map: dict[str, tuple[type[BaseEffect], type[BaseConfig]]] = {}
 
-    def _register_effect_from_module(module: ModuleType) -> None:
-        """Register an effect module's resources and populate its CLI options.
-
-        If the module defines `get_effect_resources()`, that callable is expected to
-        return the effect command name, effect class, and config class. The config class
-        is then used to populate the subparser for that effect command.
-
-        Args:
-            module: The module to inspect for effect resources.
-
-        Raises:
-            ValueError: If the module registers an effect command that has already been
-                registered.
-
-        """
-        if hasattr(module, "get_effect_resources"):
-            effect_cmd: str
-            effect_class: type[BaseEffect]
-            config_class: type[BaseConfig]
-            effect_cmd, effect_class, config_class = module.get_effect_resources()
-            if effect_cmd in effect_resource_map:
-                msg = f"Duplicate effect command detected: {effect_cmd}"
-                raise ValueError(msg)
-            effect_resource_map[effect_cmd] = (effect_class, config_class)
-            config_class._populate_parser(subparsers)
-
-    for module_info in pkgutil.iter_modules(
-        terminaltexteffects.effects.__path__,
-        terminaltexteffects.effects.__name__ + ".",
-    ):
-        module = importlib.import_module(module_info.name)
-        _register_effect_from_module(module)
-
-    plugins_dir = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "terminaltexteffects" / "effects"
-    if plugins_dir.exists():
-        for plugin_file in plugins_dir.glob("*.py"):
-            if plugin_file.name == "__init__.py":
-                continue
-            module_name = plugin_file.stem
-            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                spec.loader.exec_module(module)
-                _register_effect_from_module(module)
+    _register_discovered_effects(subparsers, effect_resource_map)
 
     return parser, effect_resource_map
 

--- a/terminaltexteffects/effects/effect_beams.py
+++ b/terminaltexteffects/effects/effect_beams.py
@@ -341,8 +341,12 @@ class BeamsIterator(BaseEffectIterator[BeamsConfig]):
             inner_fill_chars=True,
         ):
             groups.append(BeamsIterator.Group(column, "column", self.terminal, self.config))  # noqa: PERF401
+        configured_characters: set[tte.EffectCharacter] = set()
         for group in groups:
             for character in group.characters:
+                if character in configured_characters:
+                    continue
+                configured_characters.add(character)
                 beam_row_scn = character.animation.new_scene(scene_id="beam_row")
                 beam_column_scn = character.animation.new_scene(scene_id="beam_column")
                 brigthen_scn = character.animation.new_scene(scene_id="brighten")
@@ -393,7 +397,11 @@ class BeamsIterator(BaseEffectIterator[BeamsConfig]):
                         bg_gradient=bg_brighten_gradient,
                     )
                 else:
-                    brigthen_scn.add_frame(character.input_symbol, self.config.final_gradient_frames, colors=tte.ColorPair())
+                    brigthen_scn.add_frame(
+                        character.input_symbol,
+                        self.config.final_gradient_frames,
+                        colors=tte.ColorPair(),
+                    )
 
         self.pending_groups = groups
         random.shuffle(self.pending_groups)

--- a/terminaltexteffects/engine/animation.py
+++ b/terminaltexteffects/engine/animation.py
@@ -18,6 +18,7 @@ from terminaltexteffects.utils import ansitools, colorterm, easing, graphics, he
 from terminaltexteffects.utils.exceptions import (
     ActivateEmptySceneError,
     AnimationSceneError,
+    DuplicateSceneIDError,
     FrameDurationError,
     SceneNotFoundError,
 )
@@ -198,6 +199,7 @@ class Scene:
         self.easing_current_step: int = 0
         self.preexisting_colors: graphics.ColorPair | None = None
         self.preexisting_bold: bool = False
+        self._loop_cycle_complete: bool = False
 
     def _get_color_code(self, color: graphics.Color | None) -> str | int | None:
         """Get the color code for the given color.
@@ -328,6 +330,7 @@ class Scene:
             CharacterVisual: The visual of the current frame in the Scene.
 
         """
+        self._loop_cycle_complete = False
         current_frame = self.frames[0]
         next_visual = current_frame.character_visual
         current_frame.ticks_elapsed += 1
@@ -337,6 +340,7 @@ class Scene:
             if self.is_looping and not self.frames:
                 self.frames.extend(self.played_frames)
                 self.played_frames.clear()
+                self._loop_cycle_complete = True
         return next_visual
 
     def apply_gradient_to_symbols(
@@ -359,7 +363,8 @@ class Scene:
             None
 
         Raises:
-            AnimationSceneError: if gradients are invalid or symbols are invalid
+            AnimationSceneError: If the gradients are invalid, the symbol sequence is empty, or any symbol is not
+                exactly one character long.
 
         """
         T = typing.TypeVar("T")
@@ -415,8 +420,11 @@ class Scene:
                 "Foreground and background gradient are empty. At least one gradient must have at least one color."
             )
             raise AnimationSceneError(message)
+        if not symbols:
+            message = "Symbols must contain at least one symbol."
+            raise AnimationSceneError(message)
         for symbol in symbols:
-            if len(symbol) > 1:
+            if len(symbol) != 1:
                 message = f"Symbol must be a string with a length of 1. Received: `{symbol}`."
                 raise AnimationSceneError(message)
         color_pairs: list[graphics.ColorPair] = []
@@ -457,6 +465,7 @@ class Scene:
         self.frames.extend(self.played_frames)
         self.played_frames.clear()
         self.easing_current_step = 0
+        self._loop_cycle_complete = False
 
     def __eq__(self, other: object) -> bool:
         """Check if two Scene objects are equal based on their scene_id."""
@@ -562,8 +571,7 @@ class Animation:
         """Create a new Scene and add it to the Animation.
 
         If no ID is provided, a unique ID is generated. If `existing_color_handling` is `"always"`,
-        the Scene inherits the animation's input colors as `preexisting_colors`. If a Scene with the
-        same ID already exists, it is replaced in the animation's scene mapping.
+        the Scene inherits the animation's input colors as `preexisting_colors`.
 
         Args:
             scene_id (str): Name for the scene. Used to query for the scene.
@@ -573,6 +581,9 @@ class Animation:
 
         Returns:
             Scene: The new Scene.
+
+        Raises:
+            DuplicateSceneIDError: If an explicitly provided Scene ID has already been used.
 
         """
         if not scene_id:
@@ -584,8 +595,8 @@ class Animation:
                     found_unique = True
                 else:
                     current_id += 1
-        # Future: review whether scene IDs should be enforced as unique and raise on duplicates.
-        # Confirm no effects intentionally overwrite scenes today, then update this behavior and docs together.
+        elif scene_id in self.scenes:
+            raise DuplicateSceneIDError(scene_id)
         if self.existing_color_handling == "always" and self.character.uses_input_preexisting_colors:
             preexisting_colors = graphics.ColorPair(fg=self.input_fg_color, bg=self.input_bg_color)
             preexisting_bold = self.input_bold
@@ -796,14 +807,17 @@ class Animation:
             * Synced scenes select a frame based on the active motion path's progress.
             * Eased scenes select a frame from `frame_index_map` using easing progress.
             * All other scenes advance by consuming frame duration through `Scene.get_next_visual()`.
-            * If a synced scene no longer has an active motion path, the final frame is applied and
-              the scene is marked complete.
+            * If a synced scene no longer has an active motion path, the final frame is applied. A
+              non-looping synced scene is then marked complete, while a looping scene keeps its frames.
             * When a non-looping scene completes, it is reset, deactivated, and a `SCENE_COMPLETE`
               event is triggered.
+            * Looping sequential and eased scenes trigger `SCENE_COMPLETE` once when each playback cycle wraps.
+              Synced looping scenes rely on their associated motion path events instead.
         """
         scene = self.active_scene
         if scene is None or not scene.frames:
             return
+        scene._loop_cycle_complete = False
 
         if scene.sync:
             self._step_synced_scene(scene)
@@ -819,6 +833,8 @@ class Animation:
         active_path = self.character.motion.active_path
         if active_path is None:
             self.current_character_visual = scene.frames[-1].character_visual
+            if scene.is_looping:
+                return
             scene.played_frames.extend(scene.frames)
             scene.frames.clear()
             return
@@ -853,13 +869,17 @@ class Animation:
         if scene.easing_current_step == scene.easing_total_steps:
             if scene.is_looping:
                 scene.easing_current_step = 0
+                scene._loop_cycle_complete = True
             else:
                 scene.played_frames.extend(scene.frames)
                 scene.frames.clear()
 
     def _complete_scene_if_finished(self, scene: Scene) -> None:
         """Reset completed scenes and trigger completion events."""
-        if not self.active_scene_is_complete():
+        if scene.is_looping:
+            if not scene._loop_cycle_complete:
+                return
+        elif not self.active_scene_is_complete():
             return
 
         if not scene.is_looping:
@@ -898,6 +918,7 @@ class Animation:
         else:
             found_scene = scene
         self.active_scene = found_scene
+        self.active_scene._loop_cycle_complete = False
         self.active_scene_current_step = 0
         self.current_character_visual = self.active_scene.activate()
         self.character.event_handler._handle_event(self.character.event_handler.Event.SCENE_ACTIVATED, found_scene)

--- a/terminaltexteffects/utils/exceptions/__init__.py
+++ b/terminaltexteffects/utils/exceptions/__init__.py
@@ -3,6 +3,7 @@
 from terminaltexteffects.utils.exceptions.animation_exceptions import (
     ActivateEmptySceneError,
     AnimationSceneError,
+    DuplicateSceneIDError,
     FrameDurationError,
     SceneNotFoundError,
 )

--- a/terminaltexteffects/utils/exceptions/animation_exceptions.py
+++ b/terminaltexteffects/utils/exceptions/animation_exceptions.py
@@ -4,6 +4,7 @@ Classes:
     FrameDurationError: Raised when a frame is added to a Scene with an invalid duration.
     ActivateEmptySceneError: Raised when a Scene without any frames is activated.
     AnimationSceneError: Generic Scene/animation error with a provided message.
+    DuplicateSceneIDError: Raised when a Scene ID has already been used.
 
 """
 
@@ -82,4 +83,19 @@ class SceneNotFoundError(TerminalTextEffectsError):
         """
         self.scene_id = scene_id
         self.message = f"Scene with scene_id `{scene_id}` not found."
+        super().__init__(self.message)
+
+
+class DuplicateSceneIDError(TerminalTextEffectsError):
+    """Raised when a Scene is created with an ID that has already been used."""
+
+    def __init__(self, scene_id: str) -> None:
+        """Initialize a DuplicateSceneIDError.
+
+        Args:
+            scene_id: Scene ID that has already been used.
+
+        """
+        self.scene_id = scene_id
+        self.message = f"Scene ID `{scene_id}` has already been used."
         super().__init__(self.message)

--- a/tests/engine_tests/test_animation.py
+++ b/tests/engine_tests/test_animation.py
@@ -4,7 +4,7 @@ import pytest
 
 from terminaltexteffects.engine.animation import CharacterVisual, Frame, Scene
 from terminaltexteffects.engine.base_character import EffectCharacter
-from terminaltexteffects.utils import easing
+from terminaltexteffects.utils import easing, exceptions
 from terminaltexteffects.utils.exceptions import (
     ActivateEmptySceneError,
     AnimationSceneError,
@@ -180,6 +180,17 @@ def test_animation_new_scene_without_id(character: EffectCharacter) -> None:
     assert "0" in animation.scenes
 
 
+def test_animation_new_scene_duplicate_id_preserves_original(character: EffectCharacter) -> None:
+    """Reject a duplicate scene ID without replacing the original scene."""
+    animation = character.animation
+    original_scene = animation.new_scene(scene_id="test_scene")
+
+    with pytest.raises(exceptions.DuplicateSceneIDError, match="test_scene"):
+        animation.new_scene(scene_id="test_scene")
+
+    assert animation.query_scene("test_scene") is original_scene
+
+
 def test_animation_new_scene_id_generation_deleted_scene(character: EffectCharacter) -> None:
     """Test that a new scene ID is generated when the previous scene ID has been deleted."""
     for _ in range(4):
@@ -209,6 +220,32 @@ def test_animation_looping_active_scene_is_complete(character: EffectCharacter) 
     scene.add_frame(symbol="a", duration=2)
     animation.activate_scene(scene)
     assert animation.active_scene_is_complete() is True
+
+
+def test_animation_looping_scene_emits_complete_once_per_cycle(character: EffectCharacter) -> None:
+    """Emit SCENE_COMPLETE only when sequential looping playback wraps."""
+    scene = character.animation.new_scene(scene_id="test_scene", is_looping=True)
+    scene.add_frame(symbol="a", duration=2)
+    scene.add_frame(symbol="b", duration=2)
+    completed_cycles: list[str] = []
+    character.event_handler.register_event(
+        character.event_handler.Event.SCENE_COMPLETE,
+        scene,
+        character.event_handler.Action.CALLBACK,
+        character.event_handler.Callback(lambda _character: completed_cycles.append(scene.scene_id)),
+    )
+    character.animation.activate_scene(scene)
+
+    for _ in range(3):
+        character.animation.step_animation()
+    assert completed_cycles == []
+
+    character.animation.step_animation()
+    assert completed_cycles == ["test_scene"]
+
+    for _ in range(4):
+        character.animation.step_animation()
+    assert completed_cycles == ["test_scene", "test_scene"]
 
 
 def test_animation_non_looping_active_scene_is_complete(character: EffectCharacter) -> None:
@@ -422,6 +459,65 @@ def test_animation_step_animation_eased_scene_looping(character: EffectCharacter
         character.animation.step_animation()
 
 
+def test_animation_eased_looping_scene_emits_complete_once_per_cycle(character: EffectCharacter) -> None:
+    """Emit SCENE_COMPLETE only when eased looping playback wraps."""
+    scene = character.animation.new_scene(scene_id="test_scene", ease=easing.in_sine, is_looping=True)
+    scene.add_frame(symbol="a", duration=2)
+    scene.add_frame(symbol="b", duration=2)
+    completed_cycles: list[str] = []
+    character.event_handler.register_event(
+        character.event_handler.Event.SCENE_COMPLETE,
+        scene,
+        character.event_handler.Action.CALLBACK,
+        character.event_handler.Callback(lambda _character: completed_cycles.append(scene.scene_id)),
+    )
+    character.animation.activate_scene(scene)
+
+    for _ in range(3):
+        character.animation.step_animation()
+    assert completed_cycles == []
+
+    character.animation.step_animation()
+    assert completed_cycles == ["test_scene"]
+
+
+def test_animation_synced_looping_scene_does_not_emit_complete_per_tick(character: EffectCharacter) -> None:
+    """Use path events rather than per-tick completion events for synced loops."""
+    path = character.motion.new_path()
+    path.new_waypoint(Coord(10, 10))
+    character.motion.activate_path(path)
+    scene = character.animation.new_scene(scene_id="test_scene", sync=Scene.SyncMetric.STEP, is_looping=True)
+    scene.add_frame(symbol="a", duration=2)
+    scene.add_frame(symbol="b", duration=2)
+    completed_cycles: list[str] = []
+    character.event_handler.register_event(
+        character.event_handler.Event.SCENE_COMPLETE,
+        scene,
+        character.event_handler.Action.CALLBACK,
+        character.event_handler.Callback(lambda _character: completed_cycles.append(scene.scene_id)),
+    )
+    character.animation.activate_scene(scene)
+
+    for _ in range(3):
+        character.animation.step_animation()
+
+    assert completed_cycles == []
+
+
+def test_animation_synced_looping_scene_without_path_preserves_frames(character: EffectCharacter) -> None:
+    """Keep a synced looping scene reusable while no motion path is active."""
+    scene = character.animation.new_scene(scene_id="test_scene", sync=Scene.SyncMetric.STEP, is_looping=True)
+    scene.add_frame(symbol="a", duration=2)
+    scene.add_frame(symbol="b", duration=2)
+    character.animation.activate_scene(scene)
+
+    character.animation.step_animation()
+
+    assert [frame.character_visual.symbol for frame in scene.frames] == ["a", "b"]
+    assert character.animation.active_scene is scene
+    assert character.animation.current_character_visual.symbol == "b"
+
+
 def test_animation_deactivate_scene(character: EffectCharacter) -> None:
     """Verify that deactivating a scene clears the active scene reference."""
     scene = character.animation.new_scene(scene_id="test_scene")
@@ -575,6 +671,32 @@ def test_scene_apply_gradient_to_symbols_invalid_symbols(character: EffectCharac
         new_scene.apply_gradient_to_symbols(symbols, duration=1, fg_gradient=gradient)
 
 
+@pytest.mark.parametrize("symbols", ["", []])
+def test_scene_apply_gradient_to_symbols_empty_sequence(
+    character: EffectCharacter,
+    symbols: str | list[str],
+) -> None:
+    """Reject an empty symbol sequence without adding partial frames."""
+    new_scene = character.animation.new_scene(scene_id="test_scene")
+    gradient = Gradient(Color("#000000"), Color("#ffffff"), steps=2)
+
+    with pytest.raises(AnimationSceneError, match="at least one symbol"):
+        new_scene.apply_gradient_to_symbols(symbols, duration=1, fg_gradient=gradient)
+
+    assert not new_scene.frames
+
+
+def test_scene_apply_gradient_to_symbols_empty_symbol(character: EffectCharacter) -> None:
+    """Reject an empty individual symbol without adding partial frames."""
+    new_scene = character.animation.new_scene(scene_id="test_scene")
+    gradient = Gradient(Color("#000000"), Color("#ffffff"), steps=2)
+
+    with pytest.raises(AnimationSceneError, match="length of 1"):
+        new_scene.apply_gradient_to_symbols(["a", ""], duration=1, fg_gradient=gradient)
+
+    assert not new_scene.frames
+
+
 def test_scene_apply_gradient_to_symbols_single_single_step(character: EffectCharacter) -> None:
     """Verify a single-step gradient produces start and end frames."""
     new_scene = character.animation.new_scene(scene_id="test_scene")
@@ -680,8 +802,8 @@ def test_scene_reset_scene(character: EffectCharacter) -> None:
 
 def test_scene_id_equality(character: EffectCharacter) -> None:
     """Ensure scenes with matching IDs compare as equal."""
-    new_scene = character.animation.new_scene(scene_id="test_scene")
-    new_scene2 = character.animation.new_scene(scene_id="test_scene")
+    new_scene = Scene(scene_id="test_scene")
+    new_scene2 = Scene(scene_id="test_scene")
     assert new_scene == new_scene2
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,12 +17,20 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.smoke]
 
 
+def _write_plugin(tmp_path: Path, filename: str, source: str) -> Path:
+    """Write a user effect plugin and return its path."""
+    plugin_dir = tmp_path / "terminaltexteffects" / "effects"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    plugin_file = plugin_dir / filename
+    plugin_file.write_text(source.strip(), encoding="utf-8")
+    return plugin_file
+
+
 def _write_demo_plugin(tmp_path: Path) -> None:
     """Create a simple plugin effect in a temporary XDG config directory."""
-    plugin_dir = tmp_path / "terminaltexteffects" / "effects"
-    plugin_dir.mkdir(parents=True)
-    plugin_file = plugin_dir / "plugin_demo.py"
-    plugin_file.write_text(
+    _write_plugin(
+        tmp_path,
+        "plugin_demo.py",
         """
 from dataclasses import dataclass
 
@@ -47,8 +55,7 @@ class PluginDemoConfig(BaseConfig):
 
 def get_effect_resources():
     return "plugindemo", PluginDemoEffect, PluginDemoConfig
-""".strip(),
-        encoding="utf-8",
+""",
     )
 
 
@@ -172,6 +179,196 @@ def test_build_parser_includes_plugin_effect_in_completion(
     output = capsys.readouterr().out
     assert "plugindemo" in output
     assert "--plugin-speed" in output
+
+
+def test_build_parser_skips_plugin_import_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Keep valid effects available when one user plugin cannot be imported."""
+    _write_demo_plugin(tmp_path)
+    broken_plugin = _write_plugin(tmp_path, "plugin_broken.py", "def broken(:")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    _, effect_resource_map = __main__.build_parser()
+
+    assert "matrix" in effect_resource_map
+    assert "plugindemo" in effect_resource_map
+    warning = capsys.readouterr().err
+    assert str(broken_plugin) in warning
+    assert "SyntaxError" in warning
+    assert all(getattr(module, "__file__", None) != str(broken_plugin) for module in sys.modules.values())
+
+
+def test_build_parser_skips_plugin_with_mismatched_command(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Reject a plugin whose resource command and parser command differ."""
+    mismatched_plugin = _write_plugin(
+        tmp_path,
+        "plugin_mismatched.py",
+        """
+from dataclasses import dataclass
+
+from terminaltexteffects.engine.base_config import BaseConfig
+from terminaltexteffects.utils import argutils
+
+
+class MismatchedEffect:
+    pass
+
+
+@dataclass
+class MismatchedConfig(BaseConfig):
+    parser_spec = argutils.ParserSpec(
+        name="parser-command",
+        help="mismatch",
+        description="mismatch",
+        epilog="mismatch",
+    )
+
+
+def get_effect_resources():
+    return "resource-command", MismatchedEffect, MismatchedConfig
+""",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    parser, effect_resource_map = __main__.build_parser()
+
+    assert "resource-command" not in effect_resource_map
+    assert "parser-command" not in parser.format_help()
+    warning = capsys.readouterr().err
+    assert str(mismatched_plugin) in warning
+    assert "does not match" in warning
+
+
+def test_build_parser_populates_user_plugin_parser_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Register a valid plugin without invoking its parser setup twice."""
+    plugin_file = _write_plugin(
+        tmp_path,
+        "plugin_single_populate.py",
+        """
+from dataclasses import dataclass
+
+from terminaltexteffects.engine.base_config import BaseConfig
+from terminaltexteffects.utils import argutils
+
+
+class SinglePopulateEffect:
+    pass
+
+
+@dataclass
+class SinglePopulateConfig(BaseConfig):
+    parser_spec = argutils.ParserSpec(
+        name="single-populate",
+        help="single populate",
+        description="single populate",
+        epilog="single populate",
+    )
+    populate_calls = 0
+
+    @classmethod
+    def _populate_parser(cls, parser):
+        cls.populate_calls += 1
+        if cls.populate_calls > 1:
+            raise RuntimeError("parser setup called more than once")
+        super()._populate_parser(parser)
+
+
+def get_effect_resources():
+    return "single-populate", SinglePopulateEffect, SinglePopulateConfig
+""",
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    parser, effect_resource_map = __main__.build_parser()
+
+    assert "single-populate" in effect_resource_map
+    assert "single-populate" in parser.format_help()
+    assert str(plugin_file) not in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("filename", "source", "error_name"),
+    [
+        (
+            "plugin_invalid_resources.py",
+            """
+def get_effect_resources():
+    return "invalid", object
+""",
+            "ValueError",
+        ),
+        (
+            "plugin_duplicate.py",
+            """
+def get_effect_resources():
+    return "matrix", object, object
+""",
+            "ValueError",
+        ),
+        (
+            "plugin_invalid_parser.py",
+            """
+from dataclasses import dataclass
+
+from terminaltexteffects.engine.base_config import BaseConfig
+from terminaltexteffects.utils import argutils
+
+
+class InvalidParserEffect:
+    pass
+
+
+@dataclass
+class InvalidParserConfig(BaseConfig):
+    parser_spec = argutils.ParserSpec(
+        name="invalid-parser",
+        help="invalid",
+        description="invalid",
+        epilog="invalid",
+    )
+    first: int = argutils.ArgSpec(name="--duplicate-option", default=1, type=int)
+    second: int = argutils.ArgSpec(name="--duplicate-option", default=2, type=int)
+
+
+def get_effect_resources():
+    return "invalid-parser", InvalidParserEffect, InvalidParserConfig
+""",
+            "ArgumentError",
+        ),
+    ],
+)
+def test_build_parser_skips_plugin_registration_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    filename: str,
+    source: str,
+    error_name: str,
+) -> None:
+    """Keep built-ins available when a user plugin cannot be registered."""
+    broken_plugin = _write_plugin(tmp_path, filename, source)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    parser, effect_resource_map = __main__.build_parser()
+
+    assert "matrix" in effect_resource_map
+    assert "invalid" not in effect_resource_map
+    assert "invalid-parser" not in effect_resource_map
+    assert "invalid-parser" not in parser.format_help()
+    warning = capsys.readouterr().err
+    assert str(broken_plugin) in warning
+    assert error_name in warning
 
 
 def test_bash_completion_registers_in_clean_shell() -> None:


### PR DESCRIPTION
This PR fixes a handful of issues I found while reviewing the animation engine and custom effect loading.

  The main changes are:

  - Broken custom effects are now skipped with a clear warning  instead of preventing TTE from starting.
  - A failed custom effect can no longer leave behind a partially registered command.
  - Custom effect parser setup is only called once.
  - Looping scenes now emit SCENE_COMPLETE once per completed cycle.
  - Synced looping scenes keep their frames when no motion path is active.
  - Empty or invalid symbol sequences now produce a clear error.
  - Duplicate scene IDs are rejected instead of silently replacing an existing scene.
  - The Beams effect no longer depends on duplicate scene replacement.
  - The application guide and changelog have been updated.

  I also added regression tests for these cases.

  ### Testing

  - 94 CLI and animation tests passed.
  - 804 Beams configurations passed.
  - 1,444 smoke tests passed.
  - Ruff checks passed.
  - The strict documentation build passed.
  - The UV lockfile remains unchanged.